### PR TITLE
Provide default fallback for objects that aren't serializable

### DIFF
--- a/drf_ujson/renderers.py
+++ b/drf_ujson/renderers.py
@@ -38,10 +38,10 @@ class UJSONRenderer(JSONRenderer):
         ret = ujson.dumps(
             data,
             ensure_ascii=self.ensure_ascii,
-            default=encoder.default,
             escape_forward_slashes=self.escape_forward_slashes,
             encode_html_chars=self.encode_html_chars,
             indent=indent or 0,
+            default=encoder.default,
         )
 
         # force return value to unicode

--- a/drf_ujson/renderers.py
+++ b/drf_ujson/renderers.py
@@ -1,7 +1,6 @@
 from typing import Union, Optional, Mapping, Any
 
 from rest_framework.renderers import JSONRenderer
-from rest_framework.utils.encoders import JSONEncoder
 import ujson
 
 
@@ -34,7 +33,7 @@ class UJSONRenderer(JSONRenderer):
         accepted_media_type = accepted_media_type or ""
         renderer_context = renderer_context or {}
         indent = self.get_indent(accepted_media_type, renderer_context)
-        encoder = JSONEncoder()
+        encoder = self.encoder_class()
 
         ret = ujson.dumps(
             data,

--- a/drf_ujson/renderers.py
+++ b/drf_ujson/renderers.py
@@ -1,6 +1,7 @@
 from typing import Union, Optional, Mapping, Any
 
 from rest_framework.renderers import JSONRenderer
+from rest_framework.utils.encoders import JSONEncoder
 import ujson
 
 
@@ -33,10 +34,12 @@ class UJSONRenderer(JSONRenderer):
         accepted_media_type = accepted_media_type or ""
         renderer_context = renderer_context or {}
         indent = self.get_indent(accepted_media_type, renderer_context)
+        encoder = JSONEncoder()
 
         ret = ujson.dumps(
             data,
             ensure_ascii=self.ensure_ascii,
+            default=encoder.default,
             escape_forward_slashes=self.escape_forward_slashes,
             encode_html_chars=self.encode_html_chars,
             indent=indent or 0,


### PR DESCRIPTION
Use DRF JSONEncoder to provide a fallback default for objects that aren't serializable. 
This matches the default functionality of DRF JSONRenderer.